### PR TITLE
NPC movement/collision updates + Player Animation bugfix

### DIFF
--- a/public/assets/characters/alien/goblin_phaser3.json
+++ b/public/assets/characters/alien/goblin_phaser3.json
@@ -31,7 +31,7 @@
 					}
 				},
 				{
-					"filename": "goblin_attack_left_2.png",
+					"filename": "goblin_attack_left_8.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -73,7 +73,7 @@
 					}
 				},
 				{
-					"filename": "goblin_attack_left_3.png",
+					"filename": "goblin_attack_left_7.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -115,7 +115,7 @@
 					}
 				},
 				{
-					"filename": "goblin_attack_left_4.png",
+					"filename": "goblin_attack_left_6.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -199,7 +199,7 @@
 					}
 				},
 				{
-					"filename": "goblin_attack_left_7.png",
+					"filename": "goblin_attack_left_3.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -241,7 +241,7 @@
 					}
 				},
 				{
-					"filename": "goblin_attack_left_6.png",
+					"filename": "goblin_attack_left_4.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -304,7 +304,7 @@
 					}
 				},
 				{
-					"filename": "goblin_attack_left_8.png",
+					"filename": "goblin_attack_left_2.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/public/assets/characters/alien/goblin_phaser3.json
+++ b/public/assets/characters/alien/goblin_phaser3.json
@@ -346,7 +346,7 @@
 					}
 				},
 				{
-					"filename": "goblin_attack_left_1.png",
+					"filename": "goblin_attack_left_9.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -472,7 +472,7 @@
 					}
 				},
 				{
-					"filename": "goblin_attack_left_9.png",
+					"filename": "goblin_attack_left_1.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {

--- a/src/game/animations.js
+++ b/src/game/animations.js
@@ -80,18 +80,18 @@ export function createAnimations(anims = Animations.anims) {
             prefix: "goblin_attack_",
             suffix: ".png",
         }),
-        repeat: 1,
+        repeat: 0,
         frameRate: 12,
     });
     anims.create({
         key: "player-attack-left",
         frames: anims.generateFrameNames("player", {
             start: 1,
-            end: 8,
+            end: 9,
             prefix: "goblin_attack_left_",
             suffix: ".png",
         }),
-        repeat: 1,
+        repeat: 0,
         frameRate: 12,
     });
 

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -121,9 +121,9 @@ export class Game extends Scene {
         //sets size of collision box for player
         this.player.body.setSize(8, 10);
         this.player.setPushable(false);
-        const weapon = (this.weapon = this.physics.add.sprite(-50, -50));
-        weapon.setSize(25, 10);
-        weapon.setActive(false).setVisible(false);
+        // const weapon = (this.weapon = this.physics.add.sprite(-50, -50));
+        // weapon.setSize(25, 10);
+        // weapon.setActive(false).setVisible(false);
         // this.weapon = this.add.group({
         //     defaultKey: 'weapon', maxSize: 10,
         //     createCallback: function hulkSmash(weapon) {
@@ -426,71 +426,71 @@ export class Game extends Scene {
         this.player2.setVelocityY(0);
 
         //player walk right
-        let velX = 0;
-        let velY = 0;
-        if(this.player.currentState == 'walking'){
-        if (this.cursors.right.isDown) {
-            velX = speed;
-            this.player.anims.play("player-walk-right", true);
-            currentDirection = "right";
-            this.player.currentDirection = 'right'
-        }
+    //     let velX = 0;
+    //     let velY = 0;
+    //     //if(this.player.currentState == 'walking'){
+    //     if (this.cursors.right.isDown) {
+    //         velX = speed;
+    //         this.player.anims.play("player-walk-right");
+    //         currentDirection = "right";
+    //         this.player.currentDirection = 'right'
+    //     }
 
-        //player walk left
-        if (this.cursors.left.isDown) {
-            velX = -speed;
-            this.player.anims.play("player-walk-left", true);
-            currentDirection = "left";
-            this.player.currentDirection = 'left'
-        }
+    //     //player walk left
+    //     if (this.cursors.left.isDown) {
+    //         velX = -speed;
+    //         this.player.anims.play("player-walk-left");
+    //         currentDirection = "left";
+    //         this.player.currentDirection = 'left'
+    //     }
 
-        //player walk up with character facing left or right based on current direction
-        if (this.cursors.up.isDown && currentDirection === "left") {
-            velY = -speed;
+    //     //player walk up with character facing left or right based on current direction
+    //     if (this.cursors.up.isDown && currentDirection === "left") {
+    //         velY = -speed;
 
-            this.player.anims.play("player-walk-left", true);
-        } else if (this.cursors.up.isDown && currentDirection === "right") {
-            velY = -speed;
+    //         this.player.anims.play("player-walk-left");
+    //     } else if (this.cursors.up.isDown && currentDirection === "right") {
+    //         velY = -speed;
 
-            this.player.anims.play("player-walk-right", true);
-        }
+    //         this.player.anims.play("player-walk-right");
+    //     }
 
-        //player walk down with character facing left or right based on current direction
-        if (this.cursors.down.isDown && currentDirection === "left") {
-            velY = speed;
+    //     //player walk down with character facing left or right based on current direction
+    //     if (this.cursors.down.isDown && currentDirection === "left") {
+    //         velY = speed;
 
-            this.player.anims.play("player-walk-left", true);
-        } else if (this.cursors.down.isDown && currentDirection === "right") {
-            velY = speed;
-            this.player.anims.play("player-walk-right", true);
-        }
+    //         this.player.anims.play("player-walk-left");
+    //     } else if (this.cursors.down.isDown && currentDirection === "right") {
+    //         velY = speed;
+    //         this.player.anims.play("player-walk-right");
+    //     }
 
-        //player idle left or right based on current direction
-        if (velX === 0 && velY === 0 && currentDirection === "left") {
-            this.player.anims.play("player-idle-left", true);
-        } else if (velX === 0 && velY === 0 && currentDirection === "right") {
-            this.player.anims.play("player-idle-right", true);
-        }
-    }
-        // player attack right
-        if (this.cursors.space.isDown) {
-            // we'll need some method on the player sprite
-            const xPos = this.player.x;
-            const yPos = this.player.y;
-            this.player.currentState = 'attacking'
-            if (currentDirection === "left") {
-                this.player.currentDirection = 'left'
-                this.player.swingWeapon()
-                this.drawWeapon(xPos - 8, yPos - 5, this.weapon);
-            } else {
-                this.player.currentDirection = 'right'
-                this.player.swingWeapon()
-                this.drawWeapon(xPos + 8, yPos - 5, this.weapon);
-            }
-            this.time.delayedCall(600, ()=> {this.player.currentState = 'walking'})
-        }
-        //keeps player from continuing to move after pressing key
-        this.player.setVelocity(velX, velY);
+    //     //player idle left or right based on current direction
+    //     if (velX === 0 && velY === 0 && currentDirection === "left") {
+    //         this.player.anims.play("player-idle-left");
+    //     } else if (velX === 0 && velY === 0 && currentDirection === "right") {
+    //         this.player.anims.play("player-idle-right");
+    //     }
+    // //}
+    //     // player attack right
+    //     if (this.cursors.space.isDown) {
+    //         // we'll need some method on the player sprite
+    //         const xPos = this.player.x;
+    //         const yPos = this.player.y;
+    //         this.player.currentState = 'attacking'
+    //         if (currentDirection === "left") {
+    //             this.player.currentDirection = 'left'
+    //             this.player.swingWeapon()
+    //             this.drawWeapon(xPos - 8, yPos - 5, this.weapon);
+    //         } else {
+    //             this.player.currentDirection = 'right'
+    //             this.player.swingWeapon()
+    //             this.drawWeapon(xPos + 8, yPos - 5, this.weapon);
+    //         }
+    //         this.time.delayedCall(600, ()=> {this.player.currentState = 'walking'})
+    //     }
+    //     //keeps player from continuing to move after pressing key
+    //     this.player.setVelocity(velX, velY);
 
         // this.time.delayedCall(25000, () => {
         //     this.scene.start("Fight");

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -1,5 +1,5 @@
 import { EventBus } from "../EventBus";
-import { Scene, Math} from "phaser";
+import { Scene, Math } from "phaser";
 import AnimatedTiles from "phaser-animated-tiles-phaser3.5/dist/AnimatedTiles.min.js";
 import { Player } from "../sprites/Player";
 import { humanSprite } from "../sprites/humanSprite";
@@ -16,7 +16,7 @@ export class Game extends Scene {
         this.player;
         this.human;
         this.playerPosition = { x: 300, y: 400 };
-        this.weapon
+        this.weapon;
     }
     preload() {
         this.load.image(
@@ -41,20 +41,24 @@ export class Game extends Scene {
             { frameWidth: 16, frameHeight: 16 }
         );
         this.load.spritesheet(
-            'humans',
+            "humans",
             import.meta.env.BASE_URL + " assets/humans_phaser3.png",
             { frameWidth: 16, frameHeight: 16 }
-        )
-        this.textures.addSpriteSheetFromAtlas('npc',
-            {
-                frameWidth: 16, frameHeight: 16, atlas: 'humans', frame: 'base_idle_1.png'
-            })
-        this.textures.addSpriteSheetFromAtlas('npc_longhair',
-        {
-            frameWidth: 16, frameHeight: 16, atlas: 'humans', frame: 'longhair_idle_1.png'
-        })
+        );
+        this.textures.addSpriteSheetFromAtlas("npc", {
+            frameWidth: 16,
+            frameHeight: 16,
+            atlas: "humans",
+            frame: "base_idle_1.png",
+        });
+        this.textures.addSpriteSheetFromAtlas("npc_longhair", {
+            frameWidth: 16,
+            frameHeight: 16,
+            atlas: "humans",
+            frame: "longhair_idle_1.png",
+        });
     }
-   
+
     create() {
         this.add.image(
             "gameTiles",
@@ -73,7 +77,7 @@ export class Game extends Scene {
         map.createLayer("groundLayer", tileset, 0, 0);
         const waterLayer = map.createLayer("waterLayer", tileset, 0, 0);
         //const groundEdgesLayer =
-        map.createLayer("groundEdgesLayer", tileset,0,0);
+        map.createLayer("groundEdgesLayer", tileset, 0, 0);
         const moundsRocks = map.createLayer("moundsRocks", tileset, 0, 0);
         const elevatedGroundLayer = map.createLayer(
             "elevatedGroundLayer",
@@ -99,12 +103,10 @@ export class Game extends Scene {
             "humans",
             "base_idle_1.png"
         ));
-       
 
         this.human.body.setSize(22, 20);
         human.setPushable(false);
         //adds player with physics
-     
 
         const player = (this.player = new Player(
             this,
@@ -118,10 +120,10 @@ export class Game extends Scene {
 
         //sets size of collision box for player
         this.player.body.setSize(8, 10);
-        this.player.setPushable(false)
-        const weapon = (this.weapon = this.physics.add.sprite( -50, -50));
+        this.player.setPushable(false);
+        const weapon = (this.weapon = this.physics.add.sprite(-50, -50));
         weapon.setSize(25, 10);
-        weapon.setActive(false).setVisible(false)
+        weapon.setActive(false).setVisible(false);
         // this.weapon = this.add.group({
         //     defaultKey: 'weapon', maxSize: 10,
         //     createCallback: function hulkSmash(weapon) {
@@ -131,9 +133,8 @@ export class Game extends Scene {
         //     removeCallback: function hulkSleep(weapon) {
         //         console.log('weapon go away??', weapon.name)
         //     },
-            
+
         // })
-        
 
         const player2 = (this.player2 = this.physics.add.sprite(
             350,
@@ -168,17 +169,12 @@ export class Game extends Scene {
         this.physics.add.collider(this.human, bridgePosts);
 
         // set collisions between NPC and player + world
-        this.physics.add.collider(this.player, )
+        // this.physics.add.collider(this.player);
         this.physics.add.collider(this.human, this.weapon, () => {
             console.log("A HIT A HIT");
-            this.weapon.setPosition(-50, -50)
+            this.weapon.setPosition(-50, -50);
 
-            this.human.anims.play("human-hurt-right");
-
-            this.playerPosition = { x: this.player.x, y: this.player.y };
-            console.log(this.playerPosition);
-
-            //fadeout to fight scene
+           //fadeout to fight scene
             this.cameras.main.fadeOut(800, 0, 0, 0, (camera, progress) => {
                 if (progress === 1) {
                     //passes reference to fight scene and fixes blue border issue with fight scene
@@ -189,7 +185,7 @@ export class Game extends Scene {
                 }
             });
         });
-        
+
         this.physics.add.collider(this.human, waterLayer);
         this.physics.add.collider(this.human, houseLayer1);
         this.physics.add.collider(this.human, houseLayer2);
@@ -225,8 +221,7 @@ export class Game extends Scene {
         // prevent player from walking off of the map
         player.setCollideWorldBounds(true);
 
-        
-        createAnimations(this.anims)
+        createAnimations(this.anims);
 
         //player.anims.play("player-attack-right");
         player2.anims.play("player-hurt-right");
@@ -234,66 +229,137 @@ export class Game extends Scene {
         this.cameras.main.shake(900, 0.0007);
         //this.cameras.flash(300);
         //this.cameras.fade(300);
-        
 
         /////////////
         // Working NPC Code
         ///////////
-       
+
         for (var i = 0; i < 12; i++) {
             var x = Math.RND.between(0, map.widthInPixels);
             var y = Math.RND.between(0, map.heightInPixels);
             // parameters are x, y, width, height
             //this.spawns.create(x, y, 65, 65);
-            let enemy = (this.enemy = new humanSprite(this, x, y, 'humans', 'base_idle_1.png'))
-            enemy.setSize(12, 15)
-            enemy.setPushable(false)
-            enemy.setCollideWorldBounds(true)
-            this.physics.add.existing(enemy)
-            if (enemy.facing === 'left') {
-                enemy.anims.play('human-walk-left')
+            let enemy = (this.enemy = new humanSprite(
+                this,
+                x,
+                y,
+                "humans",
+                "base_idle_1.png"
+            ));
+            enemy.setSize(12, 15);
+            enemy.setPushable(false);
+            enemy.setCollideWorldBounds(true);
+            // this.physics.add.existing(enemy)
+            if (enemy.facing === "left") {
+                enemy.anims.play("human-walk-left");
             } else {
-                enemy.anims.play('human-walk-right')
+                enemy.anims.play("human-walk-right");
             }
-        enemy.body.onCollide = true   
-        this.physics.add.collider(enemy, waterLayer, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, houseLayer1, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, houseLayer2, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, treeLayer, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, moundsRocks, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, fenceLayer, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, crops, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, elevatedGroundLayer, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, bridgePosts, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, this.player, enemy.handleCollision, undefined, this);
-        this.physics.add.collider(enemy, this.weapon, () => {
-            console.log("A HIT A HIT");
-            this.weapon.setPosition(-50, -50)
-            enemy.setVelocity(0, 0)
-            //enemy.takeDamage()
-            enemy.anims.play('human-hurt-right')
-            
+            enemy.body.onCollide = true;
+            if (
+                enemy.body.x <= 6 ||
+                enemy.body.x > 794 ||
+                enemy.body.y < 6 ||
+                enemy.body.x > 760
+            ) {
+                enemy.changeDirection();
+            }
+            this.physics.add.collider(
+                enemy,
+                waterLayer,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
+            this.physics.add.collider(
+                enemy,
+                houseLayer1,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
+            this.physics.add.collider(
+                enemy,
+                houseLayer2,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
+            this.physics.add.collider(
+                enemy,
+                treeLayer,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
+            this.physics.add.collider(
+                enemy,
+                moundsRocks,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
+            this.physics.add.collider(
+                enemy,
+                fenceLayer,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
+            this.physics.add.collider(
+                enemy,
+                crops,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
+            this.physics.add.collider(
+                enemy,
+                elevatedGroundLayer,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
+            this.physics.add.collider(
+                enemy,
+                bridgePosts,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
 
-            this.playerPosition = { x: this.player.x, y: this.player.y };
+            this.physics.add.collider(
+                enemy,
+                this.player,
+                enemy.handleCollision,
+                undefined,
+                this
+            );
+            this.physics.add.collider(enemy, this.weapon, () => {
+                console.log("A HIT A HIT");
+                this.weapon.setPosition(-50, -50);
+                enemy.setVelocity(0, 0);
+                enemy.currentState = 'smacked'
+                //enemy.takeDamage()
+                enemy.killNPC();
 
-            console.log(this.playerPosition);
-
-            //fadeout to fight scene
-            this.cameras.main.fadeOut(800, 0, 0, 0, (camera, progress) => {
-                if (progress === 1) {
-                    //passes reference to fight scene and fixes blue border issue with fight scene
-                    this.scene.launch("Fight", {
-                        playerPosition: this.playerPosition,
-                        player: this.player,
+                //fadeout to fight scene
+                this.time.delayedCall(800, () => {
+                    this.cameras.main.fadeOut(800, 0, 0, 0, (camera, progress) => {
+                        if (progress === 1) {
+                            //passes reference to fight scene and fixes blue border issue with fight scene
+                            this.scene.launch("Fight", {
+                                playerPosition: this.playerPosition,
+                                player: this.player,
+                            });
+                        }
                     });
-                }
+                })
+                
             });
-        
-        });
-            
         }
         // this.physics.add.overlap(player, this.spawns, this.onNPCZoneEnter, false, this);
-        
+
         // let npcGroup = this.physics.add.group({
         //     key: 'humans',
         //     maxSize: 12,
@@ -302,7 +368,7 @@ export class Game extends Scene {
         //     let x = Math.RND.between(0, map.widthInPixels);
         //     let y = Math.RND.between(0, map.heightInPixels);
         //     let npc = npcGroup.get(x, y)
-            
+
         // }
 
         // supposed to listen to the attack animations and wait for them to complete
@@ -313,7 +379,7 @@ export class Game extends Scene {
     changeScene() {
         this.scene.start("GameOver");
     }
-    
+
     spawnNPCZones() {}
     onNPCZoneEnter() {
         // what happens when player enters NPC Zone
@@ -321,26 +387,28 @@ export class Game extends Scene {
         //this.cameras.main.shake(300);
         this.cameras.main.flash(300);
         // this.cameras.fade(300);
-        let playerX = this.player.x
-        let playerY = this.player.y
-        this.zoneHuman = new humanSprite(this, playerX + 25, playerY , 'humans',"base_idle_1.png" )
+        let playerX = this.player.x;
+        let playerY = this.player.y;
+        this.zoneHuman = new humanSprite(
+            this,
+            playerX + 25,
+            playerY,
+            "humans",
+            "base_idle_1.png"
+        );
         this.zoneHuman.body.setSize(22, 20);
         this.zoneHuman.setPushable(false);
     }
     drawWeapon(x, y, obj) {
-        
-        obj.setActive(true)
-        obj.setVisible(true)
-        
-        obj.setPosition(x, y)
+        obj.setActive(true);
+        obj.setVisible(true);
+
+        obj.setPosition(x, y);
         //setTimeout(this.sheathWeapon, 250, obj)
-        this.time.delayedCall(300, this.sheathWeapon, [obj])
+        this.time.delayedCall(300, this.sheathWeapon, [obj]);
     }
     sheathWeapon(obj) {
-        
-        obj.setPosition(-50, -50)
-        
-
+        obj.setPosition(-50, -50);
     }
     something(direction) {
         if (direction === "left") {
@@ -357,13 +425,12 @@ export class Game extends Scene {
     update() {
         //setting player position refernce for transition back from fight scene
         this.playerPosition = { x: this.player.x, y: this.player.y };
-
         // keeps players and NPCs from moving when they collide
         this.human.setVelocityX(0);
         this.human.setVelocityY(0);
         this.player2.setVelocityX(0);
         this.player2.setVelocityY(0);
-        
+
         //player walk right
         let velX = 0;
         let velY = 0;
@@ -412,23 +479,14 @@ export class Game extends Scene {
             // we'll need some method on the player sprite
             const xPos = this.player.x;
             const yPos = this.player.y;
-            
+
             if (currentDirection === "left") {
                 //this.player.anims.play('player-attack-left', true)
                 this.something(currentDirection);
-                this.drawWeapon(xPos - 8, yPos - 5, this.weapon)
-                
-                
-                
-                
+                this.drawWeapon(xPos - 8, yPos - 5, this.weapon);
             } else {
                 this.player.anims.play("player-attack-right", true);
-                this.drawWeapon(xPos + 8, yPos - 5, this.weapon)
-                 
-                
-               
-                
-                
+                this.drawWeapon(xPos + 8, yPos - 5, this.weapon);
             }
         }
         //keeps player from continuing to move after pressing key
@@ -437,8 +495,7 @@ export class Game extends Scene {
         // this.time.delayedCall(25000, () => {
         //     this.scene.start("Fight");
         // });
-        
+
         //this.sheathWeapon(this.weapon)
-        
     }
 }

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -410,13 +410,7 @@ export class Game extends Scene {
     sheathWeapon(obj) {
         obj.setPosition(-50, -50);
     }
-    something(direction) {
-        if (direction === "left") {
-            this.player.anims.play("player-attack-left", true);
-        } else {
-            this.player.anims.play("player-attack-right", true);
-        }
-    }
+    
 
     // changeScene() {
     //     this.scene.start("GameOver");
@@ -434,10 +428,12 @@ export class Game extends Scene {
         //player walk right
         let velX = 0;
         let velY = 0;
+        if(this.player.currentState == 'walking'){
         if (this.cursors.right.isDown) {
             velX = speed;
             this.player.anims.play("player-walk-right", true);
             currentDirection = "right";
+            this.player.currentDirection = 'right'
         }
 
         //player walk left
@@ -445,6 +441,7 @@ export class Game extends Scene {
             velX = -speed;
             this.player.anims.play("player-walk-left", true);
             currentDirection = "left";
+            this.player.currentDirection = 'left'
         }
 
         //player walk up with character facing left or right based on current direction
@@ -474,20 +471,23 @@ export class Game extends Scene {
         } else if (velX === 0 && velY === 0 && currentDirection === "right") {
             this.player.anims.play("player-idle-right", true);
         }
+    }
         // player attack right
         if (this.cursors.space.isDown) {
             // we'll need some method on the player sprite
             const xPos = this.player.x;
             const yPos = this.player.y;
-
+            this.player.currentState = 'attacking'
             if (currentDirection === "left") {
-                //this.player.anims.play('player-attack-left', true)
-                this.something(currentDirection);
+                this.player.currentDirection = 'left'
+                this.player.swingWeapon()
                 this.drawWeapon(xPos - 8, yPos - 5, this.weapon);
             } else {
-                this.player.anims.play("player-attack-right", true);
+                this.player.currentDirection = 'right'
+                this.player.swingWeapon()
                 this.drawWeapon(xPos + 8, yPos - 5, this.weapon);
             }
+            this.time.delayedCall(600, ()=> {this.player.currentState = 'walking'})
         }
         //keeps player from continuing to move after pressing key
         this.player.setVelocity(velX, velY);

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -12,7 +12,7 @@ export class Game extends Scene {
         this.player;
         this.human;
         this.playerPosition = { x: 300, y: 400 };
-        this.weapon;
+        
     }
     preload() {
         this.load.image(
@@ -117,10 +117,10 @@ export class Game extends Scene {
         //sets size of collision box for player
         this.player.body.setSize(8, 10);
         this.player.setPushable(false);
-        // const weapon = (this.weapon = this.physics.add.sprite(-50, -50));
+        // const weapon = (this.player.weapon = this.physics.add.sprite(-50, -50));
         // weapon.setSize(25, 10);
         // weapon.setActive(false).setVisible(false);
-        // this.weapon = this.add.group({
+        // this.player.weapon = this.add.group({
         //     defaultKey: 'weapon', maxSize: 10,
         //     createCallback: function hulkSmash(weapon) {
         //         weapon.setName(`drawSword`)
@@ -159,16 +159,16 @@ export class Game extends Scene {
         this.physics.add.collider(this.human, houseLayer2);
         this.physics.add.collider(this.human, treeLayer);
         this.physics.add.collider(this.human, moundsRocks);
-        this.physics.add.collider(this.human, fenceLayer);
+        this.physics.add.collider(this.human, fenceLayer), ()=>{console.log('hit the fence')};
         this.physics.add.collider(this.human, crops);
         this.physics.add.collider(this.human, elevatedGroundLayer);
         this.physics.add.collider(this.human, bridgePosts);
 
         // set collisions between NPC and player + world
         // this.physics.add.collider(this.player);
-        this.physics.add.collider(this.human, this.weapon, () => {
+        this.physics.add.collider(this.human, this.player.weapon, () => {
             console.log("A HIT A HIT");
-            this.weapon.setPosition(-50, -50);
+            this.player.weapon.setPosition(-50, -50);
 
            //fadeout to fight scene
             this.cameras.main.fadeOut(800, 0, 0, 0, (camera, progress) => {
@@ -217,6 +217,7 @@ export class Game extends Scene {
         // prevent player from walking off of the map
         player.setCollideWorldBounds(true);
 
+        // create all player, NPC animations
         createAnimations(this.anims);
 
         //player.anims.play("player-attack-right");
@@ -331,9 +332,9 @@ export class Game extends Scene {
                 undefined,
                 this
             );
-            this.physics.add.collider(enemy, this.weapon, () => {
+            this.physics.add.collider(enemy, this.player.weapon, () => {
                 console.log("A HIT A HIT");
-                this.weapon.setPosition(-50, -50);
+                
                 enemy.setVelocity(0, 0);
                 enemy.currentState = 'smacked'
                 //enemy.takeDamage()
@@ -407,7 +408,7 @@ export class Game extends Scene {
         this.human.setVelocityY(0);
         this.player2.setVelocityX(0);
         this.player2.setVelocityY(0);
-
+        
         
 
         // this.time.delayedCall(25000, () => {

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -5,14 +5,12 @@ import { Player } from "../sprites/Player";
 import { humanSprite } from "../sprites/humanSprite";
 import { createAnimations } from "../animations";
 
-
 export class Game extends Scene {
     constructor() {
         super("Game");
         this.player;
         this.human;
         this.playerPosition = { x: 300, y: 400 };
-        
     }
     preload() {
         this.load.image(
@@ -117,20 +115,6 @@ export class Game extends Scene {
         //sets size of collision box for player
         this.player.body.setSize(8, 10);
         this.player.setPushable(false);
-        // const weapon = (this.player.weapon = this.physics.add.sprite(-50, -50));
-        // weapon.setSize(25, 10);
-        // weapon.setActive(false).setVisible(false);
-        // this.player.weapon = this.add.group({
-        //     defaultKey: 'weapon', maxSize: 10,
-        //     createCallback: function hulkSmash(weapon) {
-        //         weapon.setName(`drawSword`)
-        //         console.log('created', weapon.name)
-        //     },
-        //     removeCallback: function hulkSleep(weapon) {
-        //         console.log('weapon go away??', weapon.name)
-        //     },
-
-        // })
 
         const player2 = (this.player2 = this.physics.add.sprite(
             350,
@@ -159,18 +143,20 @@ export class Game extends Scene {
         this.physics.add.collider(this.human, houseLayer2);
         this.physics.add.collider(this.human, treeLayer);
         this.physics.add.collider(this.human, moundsRocks);
-        this.physics.add.collider(this.human, fenceLayer), ()=>{console.log('hit the fence')};
+        this.physics.add.collider(this.human, fenceLayer),
+            () => {
+                console.log("hit the fence");
+            };
         this.physics.add.collider(this.human, crops);
         this.physics.add.collider(this.human, elevatedGroundLayer);
         this.physics.add.collider(this.human, bridgePosts);
 
         // set collisions between NPC and player + world
-        // this.physics.add.collider(this.player);
         this.physics.add.collider(this.human, this.player.weapon, () => {
             console.log("A HIT A HIT");
             this.player.weapon.setPosition(-50, -50);
 
-           //fadeout to fight scene
+            //fadeout to fight scene
             this.cameras.main.fadeOut(800, 0, 0, 0, (camera, progress) => {
                 if (progress === 1) {
                     //passes reference to fight scene and fixes blue border issue with fight scene
@@ -220,12 +206,9 @@ export class Game extends Scene {
         // create all player, NPC animations
         createAnimations(this.anims);
 
-        //player.anims.play("player-attack-right");
         player2.anims.play("player-hurt-right");
         human.anims.play("human-walk-right");
         this.cameras.main.shake(900, 0.0007);
-        //this.cameras.flash(300);
-        //this.cameras.fade(300);
 
         /////////////
         // Working NPC Code
@@ -246,7 +229,7 @@ export class Game extends Scene {
             enemy.setSize(12, 15);
             enemy.setPushable(false);
             enemy.setCollideWorldBounds(true);
-            // this.physics.add.existing(enemy)
+
             if (enemy.facing === "left") {
                 enemy.anims.play("human-walk-left");
             } else {
@@ -334,42 +317,31 @@ export class Game extends Scene {
             );
             this.physics.add.collider(enemy, this.player.weapon, () => {
                 console.log("A HIT A HIT");
-                
+
                 enemy.setVelocity(0, 0);
-                enemy.currentState = 'smacked'
-                //enemy.takeDamage()
+                enemy.currentState = "smacked";
                 enemy.killNPC();
 
                 //fadeout to fight scene
                 this.time.delayedCall(800, () => {
-                    this.cameras.main.fadeOut(800, 0, 0, 0, (camera, progress) => {
-                        if (progress === 1) {
-                            //passes reference to fight scene and fixes blue border issue with fight scene
-                            this.scene.launch("Fight", {
-                                playerPosition: this.playerPosition,
-                                player: this.player,
-                            });
+                    this.cameras.main.fadeOut(
+                        800,
+                        0,
+                        0,
+                        0,
+                        (camera, progress) => {
+                            if (progress === 1) {
+                                //passes reference to fight scene and fixes blue border issue with fight scene
+                                this.scene.launch("Fight", {
+                                    playerPosition: this.playerPosition,
+                                    player: this.player,
+                                });
+                            }
                         }
-                    });
-                })
-                
+                    );
+                });
             });
         }
-        // this.physics.add.overlap(player, this.spawns, this.onNPCZoneEnter, false, this);
-
-        // let npcGroup = this.physics.add.group({
-        //     key: 'humans',
-        //     maxSize: 12,
-        // })
-        // for (let z = 0; z < 12; z++){
-        //     let x = Math.RND.between(0, map.widthInPixels);
-        //     let y = Math.RND.between(0, map.heightInPixels);
-        //     let npc = npcGroup.get(x, y)
-
-        // }
-
-        // supposed to listen to the attack animations and wait for them to complete
-        //player.on(Phaser.Animations.Events.ANIMA + 'player-attack-right', () => console.log('did it!'), this)
         EventBus.emit("current-scene-ready", this);
     }
 
@@ -377,13 +349,12 @@ export class Game extends Scene {
         this.scene.start("GameOver");
     }
 
-    spawnNPCZones() {}
+    // Not currently used but an option
     onNPCZoneEnter() {
         // what happens when player enters NPC Zone
         // shake the world
-        //this.cameras.main.shake(300);
+
         this.cameras.main.flash(300);
-        // this.cameras.fade(300);
         let playerX = this.player.x;
         let playerY = this.player.y;
         this.zoneHuman = new humanSprite(
@@ -408,13 +379,9 @@ export class Game extends Scene {
         this.human.setVelocityY(0);
         this.player2.setVelocityX(0);
         this.player2.setVelocityY(0);
-        
-        
 
         // this.time.delayedCall(25000, () => {
         //     this.scene.start("Fight");
         // });
-
-        
     }
 }

--- a/src/game/scenes/Game.js
+++ b/src/game/scenes/Game.js
@@ -5,10 +5,6 @@ import { Player } from "../sprites/Player";
 import { humanSprite } from "../sprites/humanSprite";
 import { createAnimations } from "../animations";
 
-//sets players current direction
-let currentDirection = "right";
-//sets player movement speed
-let speed = 150;
 
 export class Game extends Scene {
     constructor() {
@@ -399,19 +395,6 @@ export class Game extends Scene {
         this.zoneHuman.body.setSize(22, 20);
         this.zoneHuman.setPushable(false);
     }
-    drawWeapon(x, y, obj) {
-        obj.setActive(true);
-        obj.setVisible(true);
-
-        obj.setPosition(x, y);
-        //setTimeout(this.sheathWeapon, 250, obj)
-        this.time.delayedCall(300, this.sheathWeapon, [obj]);
-    }
-    sheathWeapon(obj) {
-        obj.setPosition(-50, -50);
-    }
-    
-
     // changeScene() {
     //     this.scene.start("GameOver");
     // }
@@ -425,77 +408,12 @@ export class Game extends Scene {
         this.player2.setVelocityX(0);
         this.player2.setVelocityY(0);
 
-        //player walk right
-    //     let velX = 0;
-    //     let velY = 0;
-    //     //if(this.player.currentState == 'walking'){
-    //     if (this.cursors.right.isDown) {
-    //         velX = speed;
-    //         this.player.anims.play("player-walk-right");
-    //         currentDirection = "right";
-    //         this.player.currentDirection = 'right'
-    //     }
-
-    //     //player walk left
-    //     if (this.cursors.left.isDown) {
-    //         velX = -speed;
-    //         this.player.anims.play("player-walk-left");
-    //         currentDirection = "left";
-    //         this.player.currentDirection = 'left'
-    //     }
-
-    //     //player walk up with character facing left or right based on current direction
-    //     if (this.cursors.up.isDown && currentDirection === "left") {
-    //         velY = -speed;
-
-    //         this.player.anims.play("player-walk-left");
-    //     } else if (this.cursors.up.isDown && currentDirection === "right") {
-    //         velY = -speed;
-
-    //         this.player.anims.play("player-walk-right");
-    //     }
-
-    //     //player walk down with character facing left or right based on current direction
-    //     if (this.cursors.down.isDown && currentDirection === "left") {
-    //         velY = speed;
-
-    //         this.player.anims.play("player-walk-left");
-    //     } else if (this.cursors.down.isDown && currentDirection === "right") {
-    //         velY = speed;
-    //         this.player.anims.play("player-walk-right");
-    //     }
-
-    //     //player idle left or right based on current direction
-    //     if (velX === 0 && velY === 0 && currentDirection === "left") {
-    //         this.player.anims.play("player-idle-left");
-    //     } else if (velX === 0 && velY === 0 && currentDirection === "right") {
-    //         this.player.anims.play("player-idle-right");
-    //     }
-    // //}
-    //     // player attack right
-    //     if (this.cursors.space.isDown) {
-    //         // we'll need some method on the player sprite
-    //         const xPos = this.player.x;
-    //         const yPos = this.player.y;
-    //         this.player.currentState = 'attacking'
-    //         if (currentDirection === "left") {
-    //             this.player.currentDirection = 'left'
-    //             this.player.swingWeapon()
-    //             this.drawWeapon(xPos - 8, yPos - 5, this.weapon);
-    //         } else {
-    //             this.player.currentDirection = 'right'
-    //             this.player.swingWeapon()
-    //             this.drawWeapon(xPos + 8, yPos - 5, this.weapon);
-    //         }
-    //         this.time.delayedCall(600, ()=> {this.player.currentState = 'walking'})
-    //     }
-    //     //keeps player from continuing to move after pressing key
-    //     this.player.setVelocity(velX, velY);
+        
 
         // this.time.delayedCall(25000, () => {
         //     this.scene.start("Fight");
         // });
 
-        //this.sheathWeapon(this.weapon)
+        
     }
 }

--- a/src/game/sprites/Player.js
+++ b/src/game/sprites/Player.js
@@ -3,8 +3,7 @@ import humans from "../humans";
 export class Player extends Phaser.Physics.Arcade.Sprite {
     constructor(scene, x, y, texture) {
         super(scene, x, y, texture);
-        scene.add.existing(this);
-        scene.physics.add.existing(this);
+        
         this.inventory = [humans[1]];
         this.currentDirection = "right";
         this.currentState = "walking";
@@ -12,7 +11,9 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         this.speed = 150;
         this.weapon = this.scene.physics.add.sprite(-50, -50);
         this.weapon.setSize(30, 15);
-        this.weapon.setActive(false).setVisible(false);
+        this.weapon.setActive(true).setVisible(true);
+        scene.add.existing(this);
+        scene.physics.add.existing(this);
     }
 
     addHumanToInventory(human) {
@@ -42,8 +43,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         return this.inventory;
     }
     drawWeapon(x, y, obj) {
-        obj.setActive(true);
-        obj.setVisible(true);
+        
 
         obj.setPosition(x, y);
 

--- a/src/game/sprites/Player.js
+++ b/src/game/sprites/Player.js
@@ -6,6 +6,8 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         scene.add.existing(this);
         scene.physics.add.existing(this);
         this.inventory = [humans[1]];
+        this.currentDirection = 'right'
+        this.currentState = 'walking'
     }
 
     addHumanToInventory(human) {
@@ -20,12 +22,22 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
             this.inventory.splice(index, 1);
         }
     }
-
+    swingWeapon() {
+        if (this.currentDirection == 'right') {
+            this.anims.play('player-attack-right', true)
+        } else {
+            this.anims.play('player-attack-left', true)
+        }
+    }
     hasHuman(human) {
         return this.inventory.includes(human);
     }
 
     humanList() {
         return this.inventory;
+    }
+    preUpdate(t, dt) {
+        super.preUpdate(t, dt);
+        
     }
 }

--- a/src/game/sprites/Player.js
+++ b/src/game/sprites/Player.js
@@ -6,12 +6,11 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         scene.add.existing(this);
         scene.physics.add.existing(this);
         this.inventory = [humans[1]];
-        this.currentDirection = 'right'
-        this.currentState = 'walking'
-        this.cursors = this.scene.input.keyboard.createCursorKeys()
-        this.speed = 150
-        //
-        this.weapon = this.scene.physics.add.sprite(-50, -50)
+        this.currentDirection = "right";
+        this.currentState = "walking";
+        this.cursors = this.scene.input.keyboard.createCursorKeys();
+        this.speed = 150;
+        this.weapon = this.scene.physics.add.sprite(-50, -50);
         this.weapon.setSize(30, 15);
         this.weapon.setActive(false).setVisible(false);
     }
@@ -29,10 +28,10 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         }
     }
     swingWeapon(direction) {
-        if (direction == 'right') {
-            this.anims.play('player-attack-right', true)
+        if (direction == "right") {
+            this.anims.play("player-attack-right", true);
         } else {
-            this.anims.play('player-attack-left', true)
+            this.anims.play("player-attack-left", true);
         }
     }
     hasHuman(human) {
@@ -47,7 +46,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         obj.setVisible(true);
 
         obj.setPosition(x, y);
-        
+
         //setTimeout(this.sheathWeapon, 250, obj)
         this.scene.time.delayedCall(300, this.sheathWeapon, [obj]);
     }
@@ -55,30 +54,22 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         obj.setPosition(-50, -50);
     }
     animsManager(direction, state, xVel, yVel) {
-        if (state === 'attacking') {
-            if (direction == 'left') {
-                console.log('attack left')
+        if (state === "attacking") {
+            if (direction == "left") {
                 this.anims.play("player-attack-left", true);
             } else {
-                console.log('attack right')
                 this.anims.play("player-attack-right", true);
             }
-        }
-        else if (state === 'walking' && xVel != 0 || yVel != 0) {
-            if (direction == 'left') {
-                console.log('walk left')
+        } else if ((state === "walking" && xVel != 0) || yVel != 0) {
+            if (direction == "left") {
                 this.anims.play("player-walk-left", true);
             } else {
-                console.log('walk right')
                 this.anims.play("player-walk-right", true);
             }
-            
-        }  else  {
-            if (direction == 'left') {
-                console.log('idle left')
+        } else {
+            if (direction == "left") {
                 this.anims.play("player-idle-left", true);
             } else {
-                console.log('idle right')
                 this.anims.play("player-idle-right", true);
             }
         }
@@ -103,40 +94,45 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         // player walk up with character facing left or right based on current direction
         if (this.cursors.up.isDown && this.currentDirection === "left") {
             velY = -this.speed;
-        } else if (this.cursors.up.isDown && this.currentDirection === "right") {
+        } else if (
+            this.cursors.up.isDown &&
+            this.currentDirection === "right"
+        ) {
             velY = -this.speed;
         }
 
         //player walk down with character facing left or right based on current direction
         if (this.cursors.down.isDown && this.currentDirection === "left") {
             velY = this.speed;
-        } else if (this.cursors.down.isDown && this.currentDirection === "right") {
+        } else if (
+            this.cursors.down.isDown &&
+            this.currentDirection === "right"
+        ) {
             velY = this.speed;
         }
 
         // player attack right
         if (this.cursors.space.isDown) {
-            
-            const xPos = this.body.x;
-            const yPos = this.body.y;
-            console.log('SOMETHING WORKDS')
-            this.currentState = 'attacking'
-            this.swingWeapon(this.currentDirection)
-            if (this.currentDirection === "left") {
-                this.drawWeapon(xPos - 12, yPos - 2, this.weapon);
-            } else {
-                this.drawWeapon(xPos + 12, yPos - 2, this.weapon);
-            }
-            this.scene.time.delayedCall(750, ()=> {this.currentState = 'walking'})
+            this.currentState = "attacking";
+            this.swingWeapon(this.currentDirection);
+            this.scene.time.delayedCall(350, () => {
+                const xPos = this.body.x;
+                const yPos = this.body.y;
+                if (this.currentDirection === "left") {
+                    this.drawWeapon(xPos - 12, yPos - 2, this.weapon);
+                } else {
+                    this.drawWeapon(xPos + 12, yPos - 2, this.weapon);
+                }
+            });
+            this.scene.time.delayedCall(750, () => {
+                this.currentState = "walking";
+            });
         }
-        
-        this.setVelocity(velX, velY);
-        this.animsManager(this.currentDirection, this.currentState, velX, velY)
-        console.log(this.cursors.isDown)
-       
 
+        this.setVelocity(velX, velY);
+        this.animsManager(this.currentDirection, this.currentState, velX, velY);
     }
     update() {
-        super.update()
+        super.update();
     }
 }

--- a/src/game/sprites/Player.js
+++ b/src/game/sprites/Player.js
@@ -8,6 +8,12 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         this.inventory = [humans[1]];
         this.currentDirection = 'right'
         this.currentState = 'walking'
+        this.cursors = this.scene.input.keyboard.createCursorKeys()
+        this.speed = 150
+        this.currentDirection = 'right'
+        this.weapon = this.scene.add.sprite(-50, -50)
+        this.weapon.setSize(25, 10);
+        this.weapon.setActive(false).setVisible(false);
     }
 
     addHumanToInventory(human) {
@@ -36,8 +42,85 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     humanList() {
         return this.inventory;
     }
+    drawWeapon(x, y, obj) {
+        obj.setActive(true);
+        obj.setVisible(true);
+
+        obj.setPosition(x, y);
+        //setTimeout(this.sheathWeapon, 250, obj)
+        this.scene.time.delayedCall(300, this.sheathWeapon, [obj]);
+    }
+    sheathWeapon(obj) {
+        obj.setPosition(-50, -50);
+    }
     preUpdate(t, dt) {
         super.preUpdate(t, dt);
-        
+        //player walk right
+        let velX = 0;
+        let velY = 0;
+        //if(this.currentState == 'walking'){
+        if (this.cursors.right.isDown) {
+            velX = this.speed;
+            this.anims.play("player-walk-right");
+            this.currentDirection = "right";
+            this.currentDirection = 'right'
+        }
+
+        //player walk left
+        if (this.cursors.left.isDown) {
+            velX = -this.speed;
+            this.anims.play("player-walk-left");
+            this.currentDirection = "left";
+            this.currentDirection = 'left'
+        }
+
+        //player walk up with character facing left or right based on current direction
+        if (this.cursors.up.isDown && this.currentDirection === "left") {
+            velY = -this.speed;
+
+            this.anims.play("player-walk-left");
+        } else if (this.cursors.up.isDown && this.currentDirection === "right") {
+            velY = -this.speed;
+
+            this.anims.play("player-walk-right");
+        }
+
+        //player walk down with character facing left or right based on current direction
+        if (this.cursors.down.isDown && this.currentDirection === "left") {
+            velY = this.speed;
+
+            this.anims.play("player-walk-left");
+        } else if (this.cursors.down.isDown && this.currentDirection === "right") {
+            velY = this.speed;
+            this.anims.play("player-walk-right");
+        }
+
+        //player idle left or right based on current direction
+        if (velX === 0 && velY === 0 && this.currentDirection === "left") {
+            this.anims.play("player-idle-left");
+        } else if (velX === 0 && velY === 0 && this.currentDirection === "right") {
+            this.anims.play("player-idle-right");
+        }
+    //}
+        // player attack right
+        if (this.cursors.space.isDown) {
+            // we'll need some method on the player sprite
+            const xPos = this.x;
+            const yPos = this.y;
+            this.currentState = 'attacking'
+            if (this.currentDirection === "left") {
+                this.currentDirection = 'left'
+                this.swingWeapon()
+                this.drawWeapon(xPos - 8, yPos - 5, this.weapon);
+            } else {
+                this.currentDirection = 'right'
+                this.swingWeapon()
+                this.drawWeapon(xPos + 8, yPos - 5, this.weapon);
+            }
+            this.scene.time.delayedCall(600, ()=> {this.currentState = 'walking'})
+        }
+        //keeps player from continuing to move after pressing key
+        this.setVelocity(velX, velY);
+
     }
 }

--- a/src/game/sprites/Player.js
+++ b/src/game/sprites/Player.js
@@ -10,9 +10,9 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         this.currentState = 'walking'
         this.cursors = this.scene.input.keyboard.createCursorKeys()
         this.speed = 150
-        this.currentDirection = 'right'
-        this.weapon = this.scene.add.sprite(-50, -50)
-        this.weapon.setSize(25, 10);
+        //
+        this.weapon = this.scene.physics.add.sprite(-50, -50)
+        this.weapon.setSize(30, 15);
         this.weapon.setActive(false).setVisible(false);
     }
 
@@ -28,8 +28,8 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
             this.inventory.splice(index, 1);
         }
     }
-    swingWeapon() {
-        if (this.currentDirection == 'right') {
+    swingWeapon(direction) {
+        if (direction == 'right') {
             this.anims.play('player-attack-right', true)
         } else {
             this.anims.play('player-attack-left', true)
@@ -47,80 +47,96 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         obj.setVisible(true);
 
         obj.setPosition(x, y);
+        
         //setTimeout(this.sheathWeapon, 250, obj)
         this.scene.time.delayedCall(300, this.sheathWeapon, [obj]);
     }
     sheathWeapon(obj) {
         obj.setPosition(-50, -50);
     }
+    animsManager(direction, state, xVel, yVel) {
+        if (state === 'attacking') {
+            if (direction == 'left') {
+                console.log('attack left')
+                this.anims.play("player-attack-left", true);
+            } else {
+                console.log('attack right')
+                this.anims.play("player-attack-right", true);
+            }
+        }
+        else if (state === 'walking' && xVel != 0 || yVel != 0) {
+            if (direction == 'left') {
+                console.log('walk left')
+                this.anims.play("player-walk-left", true);
+            } else {
+                console.log('walk right')
+                this.anims.play("player-walk-right", true);
+            }
+            
+        }  else  {
+            if (direction == 'left') {
+                console.log('idle left')
+                this.anims.play("player-idle-left", true);
+            } else {
+                console.log('idle right')
+                this.anims.play("player-idle-right", true);
+            }
+        }
+    }
     preUpdate(t, dt) {
         super.preUpdate(t, dt);
         //player walk right
         let velX = 0;
         let velY = 0;
-        //if(this.currentState == 'walking'){
+        // player walk right
         if (this.cursors.right.isDown) {
             velX = this.speed;
-            this.anims.play("player-walk-right");
             this.currentDirection = "right";
-            this.currentDirection = 'right'
         }
 
-        //player walk left
+        // player walk left
         if (this.cursors.left.isDown) {
             velX = -this.speed;
-            this.anims.play("player-walk-left");
             this.currentDirection = "left";
-            this.currentDirection = 'left'
         }
 
-        //player walk up with character facing left or right based on current direction
+        // player walk up with character facing left or right based on current direction
         if (this.cursors.up.isDown && this.currentDirection === "left") {
             velY = -this.speed;
-
-            this.anims.play("player-walk-left");
         } else if (this.cursors.up.isDown && this.currentDirection === "right") {
             velY = -this.speed;
-
-            this.anims.play("player-walk-right");
         }
 
         //player walk down with character facing left or right based on current direction
         if (this.cursors.down.isDown && this.currentDirection === "left") {
             velY = this.speed;
-
-            this.anims.play("player-walk-left");
         } else if (this.cursors.down.isDown && this.currentDirection === "right") {
             velY = this.speed;
-            this.anims.play("player-walk-right");
         }
 
-        //player idle left or right based on current direction
-        if (velX === 0 && velY === 0 && this.currentDirection === "left") {
-            this.anims.play("player-idle-left");
-        } else if (velX === 0 && velY === 0 && this.currentDirection === "right") {
-            this.anims.play("player-idle-right");
-        }
-    //}
         // player attack right
         if (this.cursors.space.isDown) {
-            // we'll need some method on the player sprite
-            const xPos = this.x;
-            const yPos = this.y;
+            
+            const xPos = this.body.x;
+            const yPos = this.body.y;
+            console.log('SOMETHING WORKDS')
             this.currentState = 'attacking'
+            this.swingWeapon(this.currentDirection)
             if (this.currentDirection === "left") {
-                this.currentDirection = 'left'
-                this.swingWeapon()
-                this.drawWeapon(xPos - 8, yPos - 5, this.weapon);
+                this.drawWeapon(xPos - 12, yPos - 2, this.weapon);
             } else {
-                this.currentDirection = 'right'
-                this.swingWeapon()
-                this.drawWeapon(xPos + 8, yPos - 5, this.weapon);
+                this.drawWeapon(xPos + 12, yPos - 2, this.weapon);
             }
-            this.scene.time.delayedCall(600, ()=> {this.currentState = 'walking'})
+            this.scene.time.delayedCall(750, ()=> {this.currentState = 'walking'})
         }
-        //keeps player from continuing to move after pressing key
+        
         this.setVelocity(velX, velY);
+        this.animsManager(this.currentDirection, this.currentState, velX, velY)
+        console.log(this.cursors.isDown)
+       
 
+    }
+    update() {
+        super.update()
     }
 }

--- a/src/game/sprites/humanSprite.js
+++ b/src/game/sprites/humanSprite.js
@@ -1,96 +1,144 @@
-import { Math, Physics } from "phaser";
-
-
+import { Physics, Math } from "phaser";
 
 export class humanSprite extends Physics.Arcade.Sprite {
     constructor(scene, x, y, texture, frame) {
-        super(scene, x, y, texture, frame)
+        super(scene, x, y, texture, frame);
 
         scene.sys.updateList.add(this);
         scene.sys.displayList.add(this);
-        this.direction = 1
-        this.facing = 'right'
+        this.direction = 1;
+        this.facing = "right";
+        this.currentState = 'walking';
+
         //this.setScale(2);
+        scene.physics.add.existing(this);
         scene.physics.world.enableBody(this);
         //this.setImmovable(true);
         this.moveEvent = scene.time.addEvent({
-            delay: Math.Between(500,2500),
+            delay: Math.Between(500, 2500),
             callback: () => {
-                this.direction = this.changeDirection(this.direction)
+                this.direction = this.changeDirection();
             },
-            loop: true
-        })   
-        scene.physics.world.on(Physics.Arcade.Events.COLLIDE, this.handleCollision, this)
-       
+            loop: true,
+        });
+        scene.physics.world.on(
+            Physics.Arcade.Events.COLLIDE,
+            this.handleCollision,
+            this
+        );
+        //scene.physics.world.on('collision', this.handleCollision, this);
     }
     destroy(fromScene) {
-        this.moveEvent.destroy()
-        super.destroy(fromScene)
+        this.moveEvent.destroy();
+        super.destroy(fromScene);
     }
 
     // let's have our NPCs move around at random - None of this is working
-
-    changeDirection(direction) {
-        let newDirection = Math.Between(0, 3)
-        // while (newDirection === direction) {
-        //     newDirection = Math.Between(0,3)
-        // }
-        return newDirection
-
-    }
-    
-    handleCollision() {
+    killNPC() {
         
-        this.direction = () => {
-            let newDir = Math.Between(0, 3)
-            while (newDir === this.direction) {
-                newDir = Math.Between(0, 3)
-            }
-            return newDir       
+        this.currentState = 'smacked'
+        this.setVelocity(0, 0)
+        
+        if (this.facing == "right") {
+            this.anims.play("human-hurt-right");
+        } else {
+            this.anims.play("human-hurt-left");
+        }
+    }
+    changeDirection() {
+        if (this.currentState != 'walking') {
+            console.log( this)
+            this.setVelocity(0, 0)
+            return
         }
 
-        
-        
-        
-        
-    }
-    preUpdate(t, dt){
-        super.preUpdate(t, dt)
-        
-        const velocity = Math.RND.between(0,55)
-        let xVel = 0
-        let yVel = 0
-        if (this.direction === 0) {
-            yVel -= velocity
-        } else if (this.direction === 1) {
-            this.facing = 'right'
-            
-            xVel += velocity
-        } else if(this.direction === 2){
-            yVel += velocity
-        } else {
+        let xVel = this.body.velocity.x;
+        let yVel = this.body.velocity.y;
+        if (this.direction == 0) {
+            yVel = -yVel;
+        } else if (this.direction == 1) {
+            this.facing = "left";
 
-            this.facing = 'left'
-            
-            xVel -= velocity
+            xVel = -xVel;
+        } else if (this.direction == 2) {
+            yVel = -yVel;
+        } else {
+            this.facing = "right";
+
+            xVel = -xVel;
         }
         // play the correct animation
         if (xVel === 0 && yVel === 0) {
-            
-            if (this.facing === 'left') {
-                
-                this.anims.play('human-idle-left')
+            if (this.facing === "left") {
+                this.anims.play("human-idle-left");
             } else {
-                this.anims.play('human-idle-right')
+                this.anims.play("human-idle-right");
             }
         } else {
-            if (this.facing === 'left') {
-                this.anims.play('human-walk-left')
+            if (this.facing === "left") {
+                this.anims.play("human-walk-left");
             } else {
-                this.anims.play('human-walk-right')
+                this.anims.play("human-walk-right");
             }
         }
-        this.setVelocity(xVel, yVel)
+        this.setVelocity(xVel, yVel);
+        // this.body.velocity.x = xVel
+        // this.body.velocity.y = yVel
+
+        return Math.Between(0, 3);
+    }
+
+    handleCollision() {
+        if (this.currentState != 'walking') {
+            
+            
+            return
+        }
+
+        let newDir = Math.Between(0, 3);
+
+        while (newDir == this.direction) {
+            newDir = Math.Between(0, 3);
+        }
+        return newDir;
+    }
+    preUpdate(t, dt) {
+        super.preUpdate(t, dt);
+        if (this.currentState != 'walking') {
+            return
+        }
+
+        const velocity = Math.Between(30, 150);
+        let xVel = this.body.velocity.x;
+        let yVel = this.body.velocity.y;
+        if (this.direction === 0) {
+            yVel = -velocity;
+        } else if (this.direction === 1) {
+            this.facing = "right";
+
+            xVel = velocity;
+        } else if (this.direction === 2) {
+            yVel = velocity;
+        } else {
+            this.facing = "left";
+
+            xVel = -velocity;
+        }
+        // play the correct animation
+        if (xVel === 0 && yVel === 0) {
+            if (this.facing === "left") {
+                this.anims.play("human-idle-left");
+            } else {
+                this.anims.play("human-idle-right");
+            }
+        } else {
+            if (this.facing === "left") {
+                this.anims.play("human-walk-left");
+            } else {
+                this.anims.play("human-walk-right");
+            }
+        }
         
+        this.setVelocity(xVel, yVel);
     }
 }


### PR DESCRIPTION
Updating NPC movement to allow them to move diagonally
Updates in progress to ensure that NPC collisions always result in a change of direction

Our Player character has always had the attack animation overridden by the walking/idle animation. Currently working on ensuring the entire attack animation is able to play.